### PR TITLE
Add missing default folders.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
     env: 
       latest_version: "2.34"
       pgbackrest_completion_version: "v0.3"
+      build_platforms: "linux/amd64,linux/arm64"
     steps:
     - uses: actions/checkout@v2
 
@@ -19,22 +20,7 @@ jobs:
       id: vars
       run: |
         echo ::set-output name=repo_tag::$(echo ${GITHUB_REF} | cut -d'/' -f3)
-
-    - name: Build pgbackrest images
-      run: |
-        docker build --rm -f Dockerfile --build-arg BACKREST_VERSION=${TAG} --build-arg REPO_BUILD_TAG=${REPO_TAG} --build-arg BACKREST_COMPLETION_VERSION=${COMPL_TAG} -t pgbackrest:${TAG} .
-      env: 
-        TAG: ${{ matrix.pgbackrest_version }}
-        REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
-        COMPL_TAG: ${{ env.pgbackrest_completion_version }}
-
-    - name: Test pgbackrest images
-      run: |
-        docker run --rm pgbackrest:${TAG} pgbackrest version
-        docker inspect --format '{{ index .Config.Labels "org.label-schema.version"}}' pgbackrest:${TAG}
-      env: 
-        TAG: ${{ matrix.pgbackrest_version }}
-
+    
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
 
@@ -45,6 +31,21 @@ jobs:
     - name: Available platforms
       run: echo ${{ steps.buildx.outputs.platforms }}
 
+    - name: Build pgbackrest images
+      run: |
+        docker buildx build \
+          -f Dockerfile \
+          --platform ${BUILD_PLATFORMS} \
+          --build-arg BACKREST_VERSION=${TAG} \
+          --build-arg REPO_BUILD_TAG=${REPO_TAG} \
+          --build-arg BACKREST_COMPLETION_VERSION=${COMPL_TAG} \
+          -t pgbackrest:${TAG} .
+      env: 
+        TAG: ${{ matrix.pgbackrest_version }}
+        REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
+        COMPL_TAG: ${{ env.pgbackrest_completion_version }}
+        BUILD_PLATFORMS: ${{ env.build_platforms }}
+
     - name: Build and push tag image to ghcr.io and Docker Hub
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
       run: |
@@ -52,7 +53,7 @@ jobs:
         echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin
         docker buildx build --push \
             -f Dockerfile \
-            --platform linux/amd64,linux/arm64 \
+            --platform ${BUILD_PLATFORMS} \
             --build-arg BACKREST_VERSION=${TAG} \
             --build-arg REPO_BUILD_TAG=${REPO_TAG} \
             --build-arg BACKREST_COMPLETION_VERSION=${COMPL_TAG} \
@@ -68,6 +69,7 @@ jobs:
         TAG: ${{ matrix.pgbackrest_version }}
         REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
         COMPL_TAG: ${{ env.pgbackrest_completion_version }}
+        BUILD_PLATFORMS: ${{ env.build_platforms }}
 
 
     - name: Build and push tag (latest) image to ghcr.io and Docker Hub
@@ -77,7 +79,7 @@ jobs:
         echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin
         docker buildx build --push \
             -f Dockerfile \
-            --platform linux/amd64,linux/arm64 \
+            --platform ${BUILD_PLATFORMS} \
             --build-arg BACKREST_VERSION=${TAG} \
             --build-arg REPO_BUILD_TAG=${REPO_TAG} \
             --build-arg BACKREST_COMPLETION_VERSION=${COMPL_TAG} \
@@ -91,3 +93,4 @@ jobs:
         TAG: ${{ matrix.pgbackrest_version }}
         REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
         COMPL_TAG: ${{ env.pgbackrest_completion_version }}
+        BUILD_PLATFORMS: ${{ env.build_platforms }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin
         docker buildx build --push \
             -f Dockerfile \
-            --platform linux/amd64,linux/arm64 
+            --platform linux/amd64,linux/arm64 \
             --build-arg BACKREST_VERSION=${TAG} \
             --build-arg REPO_BUILD_TAG=${REPO_TAG} \
             --build-arg BACKREST_COMPLETION_VERSION=${COMPL_TAG} \
@@ -77,7 +77,7 @@ jobs:
         echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin
         docker buildx build --push \
             -f Dockerfile \
-            --platform linux/amd64,linux/arm64 
+            --platform linux/amd64,linux/arm64 \
             --build-arg BACKREST_VERSION=${TAG} \
             --build-arg REPO_BUILD_TAG=${REPO_TAG} \
             --build-arg BACKREST_COMPLETION_VERSION=${COMPL_TAG} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,22 +52,26 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /tmp/pgbackrest-release/src/pgbackrest /usr/bin/pgbackrest
-COPY files/entrypoint.sh /entrypoint.sh
 
-RUN chmod +x /entrypoint.sh \
-    && groupadd --gid ${BACKREST_GID} ${BACKREST_GROUP} \
+RUN groupadd --gid ${BACKREST_GID} ${BACKREST_GROUP} \
     && useradd --shell /bin/bash --uid ${BACKREST_UID} --gid ${BACKREST_GID} -m ${BACKREST_USER} \
     && mkdir -p -m 755 /etc/bash_completion.d \
-    && mkdir -p -m 755 /var/log/pgbackrest \
-    && mkdir -p -m 755 /etc/pgbackrest/conf.d \
+    && mkdir -p -m 750 /var/log/pgbackrest \
+        /var/lib/pgbackrest \
+        /var/spool/pgbackrest \
+        /etc/pgbackrest \
+        /etc/pgbackrest/conf.d \
     && touch /etc/pgbackrest/pgbackrest.conf \
-    && chmod 644 /etc/pgbackrest/pgbackrest.conf \
+    && chmod 640 /etc/pgbackrest/pgbackrest.conf \
     && chown -R ${BACKREST_USER}:${BACKREST_GROUP} \
         /var/log/pgbackrest \
-        /etc/pgbackrest\
+        /var/lib/pgbackrest \
+        /var/spool/pgbackrest \
+        /etc/pgbackrest \
     && cp /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo "${TZ}" > /etc/timezone
 
+COPY --chmod=755 files/entrypoint.sh /entrypoint.sh
 COPY --from=builder /tmp/pgbackrest-bash-completion/pgbackrest-completion.sh /etc/bash_completion.d
 
 LABEL \

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -17,7 +17,11 @@ if [ "${uid}" = "0" ]; then
         usermod -g ${BACKREST_GID} -l ${BACKREST_USER} -u ${BACKREST_UID} -m -d /home/${BACKREST_USER} pgbackrest
     fi
     # Correct user:group
-    chown -R ${BACKREST_USER}:${BACKREST_GROUP} /var/log/pgbackrest /etc/pgbackrest
+    chown -R ${BACKREST_USER}:${BACKREST_GROUP} \
+        /var/log/pgbackrest \
+        /var/lib/pgbackrest \
+        /var/spool/pgbackrest \
+        /etc/pgbackrest
     # pgBackRest completion
     echo "source /etc/bash_completion.d/pgbackrest-completion.sh" >> /home/${BACKREST_USER}/.bashrc
     exec gosu ${BACKREST_USER} "$@"


### PR DESCRIPTION
* Added missing pgBackRest folders.
* Restrict permissions are set.
* Buildx  is used for test builds on  `linux/amd64` and `linux/arm64` platforms.