### PR TITLE
Add direct tzdata installation for ubuntu base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,10 @@ ENV TZ="Europe/Moscow" \
     BACKREST_TLS_SERVER="disable"
 
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y  --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         postgresql-client \
         ca-certificates \
+        tzdata \
         libxml2 \
         gosu \
         openssh-client \
@@ -74,6 +75,7 @@ RUN groupadd --gid ${BACKREST_GID} ${BACKREST_GROUP} \
         /var/lib/pgbackrest \
         /var/spool/pgbackrest \
         /etc/pgbackrest \
+    && unlink /etc/localtime \
     && cp /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo "${TZ}" > /etc/timezone
 

--- a/e2e_tests/conf/pg/pg_prepare.sh
+++ b/e2e_tests/conf/pg/pg_prepare.sh
@@ -7,7 +7,7 @@ PG_CLUSTER="main"
 PG_BIN="/usr/lib/postgresql/13/bin"
 PG_DATA="/var/lib/postgresql/13/${PG_CLUSTER}"
 
-# Start sshd
+# Start sshd.
 /usr/sbin/sshd -f ~/sshd/sshd_config
 
 # Start postgres.


### PR DESCRIPTION
Previously , it was installed as `libxml2` dependency.