### PR TITLE
Up pgBackRest completion script version to 0.7.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
         pgbackrest_version: ["2.35", "2.36", "2.37", "2.38", "2.39"]
     env: 
       latest_version: "2.39"
-      pgbackrest_completion_version: "v0.6"
+      pgbackrest_completion_version: "v0.7"
       build_platforms: "linux/amd64,linux/arm64"
     steps:
     - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BACKREST_VERSIONS = 2.35 2.36 2.37 2.38 2.39
 TAG?=2.39
-BACKREST_COMP_VERSION?=v0.6
+BACKREST_COMP_VERSION?=v0.7
 UID := $(shell id -u)
 GID := $(shell id -g)
 

--- a/README.md
+++ b/README.md
@@ -220,11 +220,11 @@ make build_version_alpine TAG=2.39
 or
 
 ```bash
-docker build -f Dockerfile --build-arg BACKREST_VERSION=2.39 --build-arg BACKREST_COMPLETION_VERSION=v0.6 -t pgbackrest:2.39 .
+docker build -f Dockerfile --build-arg BACKREST_VERSION=2.39 --build-arg BACKREST_COMPLETION_VERSION=v0.7 -t pgbackrest:2.39 .
 ```
 
 ```bash
-docker build -f Dockerfile.alpine --build-arg BACKREST_VERSION=2.39 --build-arg BACKREST_COMPLETION_VERSION=v0.6 -t pgbackrest:2.39-alpine .
+docker build -f Dockerfile.alpine --build-arg BACKREST_VERSION=2.39 --build-arg BACKREST_COMPLETION_VERSION=v0.7 -t pgbackrest:2.39-alpine .
 ```
 
 ## Running tests


### PR DESCRIPTION
In this version of completion script the error with  `--type` option for `info` command is fixed.