### PR TITLE
Build pgBackRest images with Greenplum support.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,9 +151,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pgbackrest_version: ["2.40_arenadata2"]
+        pgbackrest_version: ["2.40_arenadata2", "2.45_arenadata2"]
     env: 
-      latest_version: "2.40_arenadata2"
+      latest_version: "2.45_arenadata2"
       download_url: "https://github.com/arenadata/pgbackrest/archive"
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: build
 
 on: [push, pull_request]
 
+env:
+  pgbackrest_completion_version: "v0.9"
+  build_platforms: "linux/amd64,linux/arm64"
+
 jobs:
   build_image:
     runs-on: ubuntu-latest
@@ -10,8 +14,7 @@ jobs:
         pgbackrest_version: ["2.41", "2.42", "2.43", "2.44", "2.45"]
     env: 
       latest_version: "2.45"
-      pgbackrest_completion_version: "v0.9"
-      build_platforms: "linux/amd64,linux/arm64"
+      download_url: "https://github.com/pgbackrest/pgbackrest/archive/release"
     steps:
     - uses: actions/checkout@v2
 
@@ -39,12 +42,14 @@ jobs:
           --build-arg BACKREST_VERSION=${TAG} \
           --build-arg REPO_BUILD_TAG=${REPO_TAG} \
           --build-arg BACKREST_COMPLETION_VERSION=${COMPL_TAG} \
+          --build-arg BACKREST_DOWNLOAD_URL=${DOWNLOAD_URL} \
           -t pgbackrest:${TAG} .
       env: 
         TAG: ${{ matrix.pgbackrest_version }}
         REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
         COMPL_TAG: ${{ env.pgbackrest_completion_version }}
         BUILD_PLATFORMS: ${{ env.build_platforms }}
+        DOWNLOAD_URL: ${{ env.download_url }}
 
     - name: Build pgbackrest alpine image
       run: |
@@ -54,12 +59,14 @@ jobs:
           --build-arg BACKREST_VERSION=${TAG} \
           --build-arg REPO_BUILD_TAG=${REPO_TAG} \
           --build-arg BACKREST_COMPLETION_VERSION=${COMPL_TAG} \
+          --build-arg BACKREST_DOWNLOAD_URL=${DOWNLOAD_URL} \
           -t pgbackrest:${TAG}-alpine .
       env: 
         TAG: ${{ matrix.pgbackrest_version }}
         REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
         COMPL_TAG: ${{ env.pgbackrest_completion_version }}
         BUILD_PLATFORMS: ${{ env.build_platforms }}
+        DOWNLOAD_URL: ${{ env.download_url }}
 
     - name: Build image and push tag to ghcr.io and Docker Hub
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -72,6 +79,7 @@ jobs:
             --build-arg BACKREST_VERSION=${TAG} \
             --build-arg REPO_BUILD_TAG=${REPO_TAG} \
             --build-arg BACKREST_COMPLETION_VERSION=${COMPL_TAG} \
+            --build-arg BACKREST_DOWNLOAD_URL=${DOWNLOAD_URL} \
             -t ghcr.io/${GITHUB_USER}/pgbackrest:${TAG} \
             -t ghcr.io/${GITHUB_USER}/pgbackrest:${TAG}-${REPO_TAG} \
             -t ${DOCKERHUB_USER}/pgbackrest:${TAG} \
@@ -85,6 +93,7 @@ jobs:
         REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
         COMPL_TAG: ${{ env.pgbackrest_completion_version }}
         BUILD_PLATFORMS: ${{ env.build_platforms }}
+        DOWNLOAD_URL: ${{ env.download_url }}
 
     - name: Build alpine image and push tag to ghcr.io and Docker Hub
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -97,6 +106,7 @@ jobs:
             --build-arg BACKREST_VERSION=${TAG} \
             --build-arg REPO_BUILD_TAG=${REPO_TAG} \
             --build-arg BACKREST_COMPLETION_VERSION=${COMPL_TAG} \
+            --build-arg BACKREST_DOWNLOAD_URL=${DOWNLOAD_URL} \
             -t ghcr.io/${GITHUB_USER}/pgbackrest:${TAG}-alpine \
             -t ghcr.io/${GITHUB_USER}/pgbackrest:${TAG}-alpine-${REPO_TAG} \
             -t ${DOCKERHUB_USER}/pgbackrest:${TAG}-alpine \
@@ -110,6 +120,7 @@ jobs:
         REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
         COMPL_TAG: ${{ env.pgbackrest_completion_version }}
         BUILD_PLATFORMS: ${{ env.build_platforms }}
+        DOWNLOAD_URL: ${{ env.download_url }}
 
     - name: Build image and push tag (latest) to ghcr.io and Docker Hub
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && matrix.pgbackrest_version == env.latest_version
@@ -122,6 +133,7 @@ jobs:
             --build-arg BACKREST_VERSION=${TAG} \
             --build-arg REPO_BUILD_TAG=${REPO_TAG} \
             --build-arg BACKREST_COMPLETION_VERSION=${COMPL_TAG} \
+            --build-arg BACKREST_DOWNLOAD_URL=${DOWNLOAD_URL} \
             -t ghcr.io/${GITHUB_USER}/pgbackrest:latest \
             -t ${DOCKERHUB_USER}/pgbackrest:latest .
       env:
@@ -133,3 +145,123 @@ jobs:
         REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
         COMPL_TAG: ${{ env.pgbackrest_completion_version }}
         BUILD_PLATFORMS: ${{ env.build_platforms }}
+        DOWNLOAD_URL: ${{ env.download_url }}
+
+  build_gpdb_image:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pgbackrest_version: ["2.40_arenadata2"]
+    env: 
+      latest_version: "2.40_arenadata2"
+      download_url: "https://github.com/arenadata/pgbackrest/archive"
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get repo tag
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+      id: vars
+      run: |
+        echo ::set-output name=repo_tag::$(echo ${GITHUB_REF} | cut -d'/' -f3)
+    
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Available platforms
+      run: echo ${{ steps.buildx.outputs.platforms }}
+
+    - name: Build pgbackrest gpdb image
+      run: |
+        IMAGE_TAG="$(echo ${TAG} | cut -d_ -f1)-gpdb"
+        docker buildx build \
+          -f Dockerfile \
+          --platform ${BUILD_PLATFORMS} \
+          --build-arg BACKREST_VERSION=${TAG} \
+          --build-arg REPO_BUILD_TAG=${REPO_TAG} \
+          --build-arg BACKREST_COMPLETION_VERSION=${COMPL_TAG} \
+          --build-arg BACKREST_DOWNLOAD_URL=${DOWNLOAD_URL} \
+          -t pgbackrest:${IMAGE_TAG} .
+      env: 
+        TAG: ${{ matrix.pgbackrest_version }}
+        REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
+        COMPL_TAG: ${{ env.pgbackrest_completion_version }}
+        BUILD_PLATFORMS: ${{ env.build_platforms }}
+        DOWNLOAD_URL: ${{ env.download_url }}
+
+    - name: Build pgbackrest gpdb alpine image
+      run: |
+        IMAGE_TAG="$(echo ${TAG} | cut -d_ -f1)-gpdb"
+        docker buildx build \
+          -f Dockerfile.alpine \
+          --platform ${BUILD_PLATFORMS} \
+          --build-arg BACKREST_VERSION=${TAG} \
+          --build-arg REPO_BUILD_TAG=${REPO_TAG} \
+          --build-arg BACKREST_COMPLETION_VERSION=${COMPL_TAG} \
+          --build-arg BACKREST_DOWNLOAD_URL=${DOWNLOAD_URL} \
+          -t pgbackrest:${IMAGE_TAG}-alpine .
+      env: 
+        TAG: ${{ matrix.pgbackrest_version }}
+        REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
+        COMPL_TAG: ${{ env.pgbackrest_completion_version }}
+        BUILD_PLATFORMS: ${{ env.build_platforms }}
+        DOWNLOAD_URL: ${{ env.download_url }}
+
+    - name: Build gpdb image and push tag to ghcr.io and Docker Hub
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+      run: |
+        echo ${GITHUB_PKG} | docker login ghcr.io -u ${GITHUB_USER} --password-stdin
+        echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin
+        IMAGE_TAG="$(echo ${TAG} | cut -d_ -f1)-gpdb"
+        docker buildx build --push \
+            -f Dockerfile \
+            --platform ${BUILD_PLATFORMS} \
+            --build-arg BACKREST_VERSION=${TAG} \
+            --build-arg REPO_BUILD_TAG=${REPO_TAG} \
+            --build-arg BACKREST_COMPLETION_VERSION=${COMPL_TAG} \
+            --build-arg BACKREST_DOWNLOAD_URL=${DOWNLOAD_URL} \
+            -t ghcr.io/${GITHUB_USER}/pgbackrest:${IMAGE_TAG} \
+            -t ghcr.io/${GITHUB_USER}/pgbackrest:${IMAGE_TAG}-${REPO_TAG} \
+            -t ${DOCKERHUB_USER}/pgbackrest:${IMAGE_TAG} \
+            -t ${DOCKERHUB_USER}/pgbackrest:${IMAGE_TAG}-${REPO_TAG} .
+      env:
+        GITHUB_USER: ${{ github.actor }}
+        GITHUB_PKG: ${{ secrets.GUTHUB_CR_PAT }}
+        DOCKERHUB_USER: ${{ secrets.DOCKEHUB_USER }}
+        DOCKERHUB_PKG: ${{ secrets.DOCKEHUB_TOKEN }}
+        TAG: ${{ matrix.pgbackrest_version }}
+        REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
+        COMPL_TAG: ${{ env.pgbackrest_completion_version }}
+        BUILD_PLATFORMS: ${{ env.build_platforms }}
+        DOWNLOAD_URL: ${{ env.download_url }}
+
+    - name: Build gpdb alpine image and push tag to ghcr.io and Docker Hub
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+      run: |
+        echo ${GITHUB_PKG} | docker login ghcr.io -u ${GITHUB_USER} --password-stdin
+        echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin
+        IMAGE_TAG="$(echo ${TAG} | cut -d_ -f1)-gpdb"
+        docker buildx build --push \
+            -f Dockerfile.alpine \
+            --platform ${BUILD_PLATFORMS} \
+            --build-arg BACKREST_VERSION=${TAG} \
+            --build-arg REPO_BUILD_TAG=${REPO_TAG} \
+            --build-arg BACKREST_COMPLETION_VERSION=${COMPL_TAG} \
+            --build-arg BACKREST_DOWNLOAD_URL=${DOWNLOAD_URL} \
+            -t ghcr.io/${GITHUB_USER}/pgbackrest:${IMAGE_TAG}-alpine \
+            -t ghcr.io/${GITHUB_USER}/pgbackrest:${IMAGE_TAG}-alpine-${REPO_TAG} \
+            -t ${DOCKERHUB_USER}/pgbackrest:${IMAGE_TAG}-alpine \
+            -t ${DOCKERHUB_USER}/pgbackrest:${IMAGE_TAG}-alpine-${REPO_TAG} .
+      env:
+        GITHUB_USER: ${{ github.actor }}
+        GITHUB_PKG: ${{ secrets.GUTHUB_CR_PAT }}
+        DOCKERHUB_USER: ${{ secrets.DOCKEHUB_USER }}
+        DOCKERHUB_PKG: ${{ secrets.DOCKEHUB_TOKEN }}
+        TAG: ${{ matrix.pgbackrest_version }}
+        REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
+        COMPL_TAG: ${{ env.pgbackrest_completion_version }}
+        BUILD_PLATFORMS: ${{ env.build_platforms }}
+        DOWNLOAD_URL: ${{ env.download_url }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:20.04 AS builder
 
 ARG BACKREST_VERSION
+ARG BACKREST_DOWNLOAD_URL="https://github.com/pgbackrest/pgbackrest/archive/release"
 ARG BACKREST_COMPLETION_VERSION
+ARG BACKREST_COMPLETION_VERSION_URL="https://github.com/woblerr/pgbackrest-bash-completion/archive"
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -21,14 +23,14 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN wget https://github.com/pgbackrest/pgbackrest/archive/release/${BACKREST_VERSION}.tar.gz -O /tmp/pgbackrest-${BACKREST_VERSION}.tar.gz \
-    && tar -xzf /tmp/pgbackrest-${BACKREST_VERSION}.tar.gz -C /tmp \
-    && mv /tmp/pgbackrest-release-${BACKREST_VERSION} /tmp/pgbackrest-release \
+RUN wget ${BACKREST_DOWNLOAD_URL}/${BACKREST_VERSION}.tar.gz -O /tmp/pgbackrest-${BACKREST_VERSION}.tar.gz \
+    && mkdir -p /tmp/pgbackrest-release \
+    && tar -xzf /tmp/pgbackrest-${BACKREST_VERSION}.tar.gz --strip-components=1 -C /tmp/pgbackrest-release \
     && cd /tmp/pgbackrest-release/src \
     && ./configure \
     && make
 
-RUN wget https://github.com/woblerr/pgbackrest-bash-completion/archive/${BACKREST_COMPLETION_VERSION}.tar.gz -O /tmp/pgbackrest-bash-completion-${BACKREST_COMPLETION_VERSION}.tar.gz \
+RUN wget ${BACKREST_COMPLETION_VERSION_URL}/${BACKREST_COMPLETION_VERSION}.tar.gz -O /tmp/pgbackrest-bash-completion-${BACKREST_COMPLETION_VERSION}.tar.gz \
     && tar -xzf /tmp/pgbackrest-bash-completion-${BACKREST_COMPLETION_VERSION}.tar.gz -C /tmp \
     && mv /tmp/pgbackrest-bash-completion-$(echo ${BACKREST_COMPLETION_VERSION} | tr -d v) /tmp/pgbackrest-bash-completion
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -78,6 +78,8 @@ RUN apk add --no-cache --update \
     && rm -rf \
         /tmp/pgbackrest-release \
         /tmp/pgbackrest-bash-completion \
+        /tmp/pgbackrest-${BACKREST_VERSION}.tar.gz \
+        /tmp/pgbackrest-bash-completion-${BACKREST_COMPLETION_VERSION}.tar.gz \
     && apk del .backrest-build \
     && rm -rf /var/cache/apk/*
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,7 +1,9 @@
 FROM alpine:3.16
 
 ARG BACKREST_VERSION
+ARG BACKREST_DOWNLOAD_URL="https://github.com/pgbackrest/pgbackrest/archive/release"
 ARG BACKREST_COMPLETION_VERSION
+ARG BACKREST_COMPLETION_VERSION_URL="https://github.com/woblerr/pgbackrest-bash-completion/archive"
 ARG REPO_BUILD_TAG
 
 ENV TZ="Etc/UTC" \
@@ -41,16 +43,16 @@ RUN apk add --no-cache --update \
         zlib-dev \
         yaml-dev \
     && ln -s /sbin/su-exec /usr/local/bin/gosu \
-    && wget https://github.com/pgbackrest/pgbackrest/archive/release/${BACKREST_VERSION}.tar.gz -O /tmp/pgbackrest-${BACKREST_VERSION}.tar.gz \
-    && tar -xzf /tmp/pgbackrest-${BACKREST_VERSION}.tar.gz -C /tmp \
-    && mv /tmp/pgbackrest-release-${BACKREST_VERSION} /tmp/pgbackrest-release \
+    && wget ${BACKREST_DOWNLOAD_URL}/${BACKREST_VERSION}.tar.gz -O /tmp/pgbackrest-${BACKREST_VERSION}.tar.gz \
+    && mkdir -p /tmp/pgbackrest-release \
+    && tar -xzf /tmp/pgbackrest-${BACKREST_VERSION}.tar.gz --strip-components=1 -C /tmp/pgbackrest-release \
     && cd /tmp/pgbackrest-release/src \
     && ./configure \
     && make \
     && cp /tmp/pgbackrest-release/src/pgbackrest /usr/bin/pgbackrest \
     && groupadd --gid ${BACKREST_GID} ${BACKREST_GROUP} \
     && useradd --shell /bin/bash --uid ${BACKREST_UID} --gid ${BACKREST_GID} -m ${BACKREST_USER} \
-    && wget https://github.com/woblerr/pgbackrest-bash-completion/archive/${BACKREST_COMPLETION_VERSION}.tar.gz -O /tmp/pgbackrest-bash-completion-${BACKREST_COMPLETION_VERSION}.tar.gz \
+    && wget ${BACKREST_COMPLETION_VERSION_URL}/${BACKREST_COMPLETION_VERSION}.tar.gz -O /tmp/pgbackrest-bash-completion-${BACKREST_COMPLETION_VERSION}.tar.gz \
     && tar -xzf /tmp/pgbackrest-bash-completion-${BACKREST_COMPLETION_VERSION}.tar.gz -C /tmp \
     && mv /tmp/pgbackrest-bash-completion-$(echo ${BACKREST_COMPLETION_VERSION} | tr -d v) /tmp/pgbackrest-bash-completion \
     && mkdir -p -m 750 /var/log/pgbackrest \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 BACKREST_VERSIONS = 2.41 2.42 2.43 2.44 2.45
 TAG?=2.45
 BACKREST_DOWNLOAD_URL = https://github.com/pgbackrest/pgbackrest/archive/release
-BACKREST_GPDB_VERSIONS = 2.40_arenadata2
-TAG_GPDB?=2.40_arenadata2
+BACKREST_GPDB_VERSIONS = 2.40_arenadata2 2.45_arenadata2
+TAG_GPDB?=2.45_arenadata2
 BACKREST_GPDB_DOWNLOAD_URL = https://github.com/arenadata/pgbackrest/archive
 BACKREST_COMP_VERSION?=v0.9
 UID := $(shell id -u)

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ build_version_gpdb:
 	$(call gpdb_image_tag,IMAGE_TAG,$(TAG_GPDB))
 	@echo "Build pgbackrest:$(IMAGE_TAG) docker image"
 	docker build --pull -f Dockerfile --build-arg BACKREST_VERSION=$(TAG_GPDB) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_GPDB_DOWNLOAD_URL) -t pgbackrest:$(IMAGE_TAG) .
-	docker run "pgbackrest:$(IMAGE_TAG)"
+	docker run pgbackrest:$(IMAGE_TAG)
 
 .PHONY: $(BACKREST_VERSIONS)-alpine
 $(addsuffix -alpine,$(BACKREST_VERSIONS)):

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Supported pgBackRest version tags:
 * `2.41`
 * `2.41-alpine`
 
+The repository also contains information for releases of pgBackRest fork with Greenplum support (see [pgbackrest/pull/1833](https://github.com/pgbackrest/pgbackrest/pull/1833)). Details - [build with Greenplum support](#build-with-greenplum-support).
+
+Supported pgBackRest version tags with Greenplum support:
+* `2.45-gpdb`
+* `2.45-gpdb-alpine`
+* `2.40-gpdb`
+* `2.40-gpdb-alpine`
+
 The image is based on the official ubuntu or alpine image. For ubuntu image each version of pgBackRest builds from the source code in a separate `builder` container. For alpine image each version of pgBackRest builds from the source code in container using virtual package `.backrest-build`.
 
 The image contains [pgbackrest-bash-completion](https://github.com/woblerr/pgbackrest-bash-completion) script. You can complete `pgbackrest` commands by pressing tab key.
@@ -239,6 +247,42 @@ docker build -f Dockerfile --build-arg BACKREST_VERSION=2.45 --build-arg BACKRES
 
 ```bash
 docker build -f Dockerfile.alpine --build-arg BACKREST_VERSION=2.45 --build-arg BACKREST_COMPLETION_VERSION=v0.9 -t pgbackrest:2.45-alpine .
+```
+
+## Build with Greenplum support
+
+PR [pgbackrest/pull/1833](https://github.com/pgbackrest/pgbackrest/pull/1833) is still not merged into pgBackRest. The separate tags `*-gpdb` are used for pgBackRest images with Greenplum support. When the PR is accepted, separate tags will no longer be needed.
+
+The image completely repeats all the possibilities of the image for pgBackRest.
+
+### Pull
+
+Change `tag` to to the version you need.
+
+* Docker Hub:
+
+```bash
+docker pull woblerr/pgbackrest:tag-gpdb
+```
+
+```bash
+docker pull woblerr/pgbackrest:tag-gpdb-alpine
+```
+
+* GitHub Registry:
+
+```bash
+docker pull ghcr.io/woblerr/pgbackrest:tag-gpdb
+```
+
+```bash
+docker pull ghcr.io/woblerr/pgbackrest:tag-gpdb-alpine
+```
+
+### Run
+
+```bash
+docker run --rm  pgbackrest:2.45-gpdb pgbackrest help
 ```
 
 ## Running tests


### PR DESCRIPTION
PR [pgbackrest/pull/1833](https://github.com/pgbackrest/pgbackrest/pull/1833) is still not merged into pgBackRest. The separate tags `*-gpdb` are used for pgBackRest images with Greenplum support. When the PR is accepted, separate tags will no longer be needed.