### PR TITLE
Delete SFTP service duplicates.

### DIFF
--- a/e2e_tests/README.md
+++ b/e2e_tests/README.md
@@ -6,7 +6,7 @@ The following architecture is used to run the tests.
 * Separate container with PostgreSQL instance and pgBackRest for backup. It's custom image, based on `docker-pgbackrest` image.
 * Separate container with pgBackRest. This is the `docker-pgbackrest` image.
 
-S3 compatible storage is described in `e2e_tests/docker-compose.s3.yml`, separate containers with `sftp` compatible storage is described in `e2e_tests/docker-compose.sftp.yml`, separate containers with PostgreSQL instances are described in `e2e_tests/docker-compose.pg.yml` and containers with pgBackRest for tests are described in `e2e_tests/docker-compose.backup-ssh.yml` for communication over `SSH` and `e2e_tests/docker-compose.backup-tls.yml` for communication over `TLS`.
+S3 compatible storage is described in `e2e_tests/docker-compose.s3.yml`, separate container with `sftp` compatible storage is described in `e2e_tests/docker-compose.sftp.yml`, separate containers with PostgreSQL instances are described in `e2e_tests/docker-compose.pg.yml` and containers with pgBackRest for tests are described in `e2e_tests/docker-compose.backup-ssh.yml` for communication over `SSH` and `e2e_tests/docker-compose.backup-tls.yml` for communication over `TLS`.
 
 ## Running tests
 

--- a/e2e_tests/conf/backup/backup_prepare-ssh.sh
+++ b/e2e_tests/conf/backup/backup_prepare-ssh.sh
@@ -6,7 +6,7 @@ set -e
 # Add hosts to known_hosts.
 # Necessary for pgBackRest to work correctly over ssh and sftp.
 ssh-keyscan -t rsa -p 2222 pg-ssh > ~/.ssh/known_hosts
-ssh-keyscan -t rsa -p 2222 sftp-ssh >> ~/.ssh/known_hosts
+ssh-keyscan -t rsa -p 2222 sftp >> ~/.ssh/known_hosts
 
 # Run pgBackRest test commands.
 pgbackrest stanza-create --stanza demo

--- a/e2e_tests/conf/pg/pg_prepare-ssh.sh
+++ b/e2e_tests/conf/pg/pg_prepare-ssh.sh
@@ -12,7 +12,7 @@ PG_DATA="/var/lib/postgresql/${PG_VERSION}/${PG_CLUSTER}"
 
 # Add host to known_hosts.
 # Necessary for pgBackRest to work correctly over sftp.
-ssh-keyscan -t rsa -p 2222 sftp-ssh > ~/.ssh/known_hosts
+ssh-keyscan -t rsa -p 2222 sftp > ~/.ssh/known_hosts
 
 # Start postgres.
 pg_ctlcluster ${PG_VERSION} ${PG_CLUSTER} start --foreground

--- a/e2e_tests/conf/pg/pg_prepare-tls.sh
+++ b/e2e_tests/conf/pg/pg_prepare-tls.sh
@@ -10,7 +10,7 @@ PG_DATA="/var/lib/postgresql/${PG_VERSION}/${PG_CLUSTER}"
 
 # Add host to known_hosts.
 # Necessary for pgBackRest to work correctly over sftp.
-ssh-keyscan -t rsa -p 2222 sftp-tls > ~/.ssh/known_hosts
+ssh-keyscan -t rsa -p 2222 sftp > ~/.ssh/known_hosts
 
 # Start postgres.
 pg_ctlcluster ${PG_VERSION} ${PG_CLUSTER} start --foreground

--- a/e2e_tests/docker-compose.backup-ssh.yml
+++ b/e2e_tests/docker-compose.backup-ssh.yml
@@ -20,7 +20,7 @@ services:
       - nginx
       - createbucket
       - pg-ssh
-      - sftp-ssh
+      - sftp
     networks:
       - ssh
 
@@ -43,7 +43,7 @@ services:
       - nginx
       - createbucket
       - pg-ssh
-      - sftp-ssh
+      - sftp
     networks:
       - ssh
 

--- a/e2e_tests/docker-compose.backup-tls.yml
+++ b/e2e_tests/docker-compose.backup-tls.yml
@@ -44,7 +44,7 @@ services:
       - createbucket
       - pg-tls
       - backup_server-tls
-      - sftp-tls
+      - sftp
     networks:
       - tls
 
@@ -69,7 +69,7 @@ services:
       - createbucket
       - pg-tls
       - backup_server-tls
-      - sftp-tls
+      - sftp
     networks:
       - tls
 

--- a/e2e_tests/docker-compose.pg.yml
+++ b/e2e_tests/docker-compose.pg.yml
@@ -20,7 +20,7 @@ services:
       - minio
       - nginx
       - createbucket
-      - sftp-ssh
+      - sftp
     networks:
       - ssh
 
@@ -44,7 +44,7 @@ services:
       - minio
       - nginx
       - createbucket
-      - sftp-tls
+      - sftp
     networks:
       - tls
 

--- a/e2e_tests/docker-compose.sftp.yml
+++ b/e2e_tests/docker-compose.sftp.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 services:
-  sftp-ssh:
+  sftp:
     build:
       context: .
       dockerfile: ./conf/sftp/Dockerfile
@@ -10,7 +10,7 @@ services:
     hostname: sftp
     command: /home/pgbackrest/sftp_prepare.sh
     volumes:
-      - "backrest_data_sftp-ssh:/var/lib/pgbackrest"
+      - "backrest_data_sftp:/var/lib/pgbackrest"
     environment:
       - "BACKREST_UID"
       - "BACKREST_GID"
@@ -19,24 +19,6 @@ services:
       - "2222"
     networks:
       - ssh
-
-  sftp-tls :
-    build:
-      context: .
-      dockerfile: ./conf/sftp/Dockerfile
-    image: sftp-pgbackrest:${TAG}
-    container_name: sftp
-    hostname: sftp
-    command: /home/pgbackrest/sftp_prepare.sh
-    volumes:
-      - "backrest_data_sftp-tls:/var/lib/pgbackrest"
-    environment:
-      - "BACKREST_UID"
-      - "BACKREST_GID"
-      - "BACKREST_TLS_SERVER=disable"
-    expose:
-      - "2222"
-    networks:
       - tls
 
 networks:
@@ -44,5 +26,4 @@ networks:
   tls:
 
 volumes:
-  backrest_data_sftp-ssh:
-  backrest_data_sftp-tls:
+  backrest_data_sftp:


### PR DESCRIPTION
There is no need to use 2 different sftp services for ssh and tls communication protocol. One is enough.