### PR TITLE
Fix e2e tests for old pgBackRest versions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,17 +92,17 @@ test-e2e-down:
 
 define run_docker_compose
 	$(call set_permissions)
-	BACKREST_UID=$(UID) BACKREST_GID=$(GID) docker-compose -f e2e_tests/docker-compose.sftp.yml -f e2e_tests/docker-compose.s3.yml -f e2e_tests/docker-compose.pg.yml up -d --build --force-recreate --always-recreate-deps pg-${1}
+	TAG=${TAG} BACKREST_UID=$(UID) BACKREST_GID=$(GID) docker-compose -f e2e_tests/docker-compose.sftp.yml -f e2e_tests/docker-compose.s3.yml -f e2e_tests/docker-compose.pg.yml up -d --build --force-recreate --always-recreate-deps pg-${1}
 	@if [ "${1}" == "tls" ]; then \
-		BACKREST_UID=$(UID) BACKREST_GID=$(GID) docker-compose -f e2e_tests/docker-compose.sftp.yml -f e2e_tests/docker-compose.s3.yml -f e2e_tests/docker-compose.pg.yml -f e2e_tests/docker-compose.backup-${1}.yml up -d --no-deps backup_server-${1}; \
+		TAG=${TAG} BACKREST_UID=$(UID) BACKREST_GID=$(GID) docker-compose -f e2e_tests/docker-compose.sftp.yml -f e2e_tests/docker-compose.s3.yml -f e2e_tests/docker-compose.pg.yml -f e2e_tests/docker-compose.backup-${1}.yml up -d --no-deps backup_server-${1}; \
 	fi
 	@sleep 30
-	BACKREST_UID=$(UID) BACKREST_GID=$(GID) docker-compose -f e2e_tests/docker-compose.sftp.yml -f e2e_tests/docker-compose.s3.yml -f e2e_tests/docker-compose.pg.yml -f e2e_tests/docker-compose.backup-${1}.yml run --rm --name backup-${1} --no-deps backup-${1}
-	BACKREST_UID=$(UID) BACKREST_GID=$(GID) docker-compose -f e2e_tests/docker-compose.sftp.yml -f e2e_tests/docker-compose.s3.yml -f e2e_tests/docker-compose.pg.yml -f e2e_tests/docker-compose.backup-${1}.yml run --rm --name backup_alpine-${1} --no-deps backup_alpine-${1}
+	TAG=${TAG} BACKREST_UID=$(UID) BACKREST_GID=$(GID) docker-compose -f e2e_tests/docker-compose.sftp.yml -f e2e_tests/docker-compose.s3.yml -f e2e_tests/docker-compose.pg.yml -f e2e_tests/docker-compose.backup-${1}.yml run --rm --name backup-${1} --no-deps backup-${1}
+	TAG=${TAG} BACKREST_UID=$(UID) BACKREST_GID=$(GID) docker-compose -f e2e_tests/docker-compose.sftp.yml -f e2e_tests/docker-compose.s3.yml -f e2e_tests/docker-compose.pg.yml -f e2e_tests/docker-compose.backup-${1}.yml run --rm --name backup_alpine-${1} --no-deps backup_alpine-${1}
 endef
 
 define down_docker_compose
-	BACKREST_UID=$(UID) BACKREST_GID=$(GID) docker-compose -f e2e_tests/docker-compose.sftp.yml -f e2e_tests/docker-compose.s3.yml -f e2e_tests/docker-compose.pg.yml -f e2e_tests/docker-compose.backup-${1}.yml down -v
+	TAG=${TAG} BACKREST_UID=$(UID) BACKREST_GID=$(GID) docker-compose -f e2e_tests/docker-compose.sftp.yml -f e2e_tests/docker-compose.s3.yml -f e2e_tests/docker-compose.pg.yml -f e2e_tests/docker-compose.backup-${1}.yml down -v
 endef
 
 define set_permissions

--- a/e2e_tests/docker-compose.pg.yml
+++ b/e2e_tests/docker-compose.pg.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: ./conf/pg/Dockerfile
       args:
         CONTAINER_TYPE: ssh
+        BACKREST_VERSION: ${TAG}
     image: pg-pgbackrest:${TAG}
     container_name: pg-ssh
     hostname: pg-ssh
@@ -30,6 +31,7 @@ services:
       dockerfile: ./conf/pg/Dockerfile
       args:
         CONTAINER_TYPE: tls
+        BACKREST_VERSION: ${TAG}
     image: pg-pgbackrest:${TAG}
     container_name: pg-tls
     hostname: pg-tls

--- a/e2e_tests/docker-compose.sftp.yml
+++ b/e2e_tests/docker-compose.sftp.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: .
       dockerfile: ./conf/sftp/Dockerfile
+      args:
+        BACKREST_VERSION: ${TAG}
     image: sftp-pgbackrest:${TAG}
     container_name: sftp
     hostname: sftp


### PR DESCRIPTION
Tag was not passed, so the containers were built with an incorrect version of pgBackRest. This has always been the latest version.