### PR TITLE
Add pgBackRest v2.52 for Greenplum.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,7 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pgbackrest_version: ["2.45_arenadata3", "2.47_arenadata4", "2.50_arenadata4"]
+        pgbackrest_version: ["2.47_arenadata4", "2.50_arenadata4", "2.52_arenadata4"]
     env: 
       download_url: "https://github.com/arenadata/pgbackrest/archive"
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 BACKREST_VERSIONS = 2.48 2.49 2.50 2.51 2.52
 TAG?=2.52
 BACKREST_DOWNLOAD_URL = https://github.com/pgbackrest/pgbackrest/archive/release
-BACKREST_GPDB_VERSIONS = 2.45_arenadata3 2.47_arenadata4 2.50_arenadata4
-TAG_GPDB?=2.50_arenadata4
+BACKREST_GPDB_VERSIONS = 2.47_arenadata4 2.50_arenadata4 2.52_arenadata4
+TAG_GPDB?=2.52_arenadata4
 BACKREST_GPDB_DOWNLOAD_URL = https://github.com/arenadata/pgbackrest/archive
 BACKREST_COMP_VERSION?=v0.9
 UID := $(shell id -u)

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ The repository also contains information for releases of pgBackRest fork with Gr
 The repository contains information for the last 3 releases of pgBackRest fork with Greenplum support. If necessary to use an older version - do a [manual build](#build).
 
 Supported pgBackRest version tags with Greenplum support:
+* `2.52-gpdb`
+* `2.52-gpdb-alpine`
 * `2.50-gpdb`
 * `2.50-gpdb-alpine`
 * `2.47-gpdb`
 * `2.47-gpdb-alpine`
-* `2.45-gpdb`
-* `2.45-gpdb-alpine`
 
 The image is based on the official ubuntu or alpine image. For ubuntu image each version of pgBackRest builds from the source code in a separate `builder` container. For alpine image each version of pgBackRest builds from the source code in container using virtual package `.backrest-build`.
 
@@ -286,7 +286,7 @@ docker pull ghcr.io/woblerr/pgbackrest:tag-gpdb-alpine
 ### Run
 
 ```bash
-docker run --rm  pgbackrest:2.47-gpdb pgbackrest help
+docker run --rm  pgbackrest:2.52-gpdb pgbackrest help
 ```
 
 ## Running tests


### PR DESCRIPTION
* Added pgBackRest `v2.52` for Greenplum.
* Deleted from README  info about pgBackRest `v2.45` with Greenplum support.