### PR TITLE
Switch the build system to meson.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
       run: |
         IMAGE_TAG="$(echo ${TAG} | cut -d_ -f1)-gpdb"
         docker buildx build \
-          -f Dockerfile \
+          -f Dockerfile_make \
           --platform ${BUILD_PLATFORMS} \
           --build-arg BACKREST_VERSION=${TAG} \
           --build-arg REPO_BUILD_TAG=${REPO_TAG} \
@@ -195,7 +195,7 @@ jobs:
       run: |
         IMAGE_TAG="$(echo ${TAG} | cut -d_ -f1)-gpdb"
         docker buildx build \
-          -f Dockerfile.alpine \
+          -f Dockerfile_make.alpine \
           --platform ${BUILD_PLATFORMS} \
           --build-arg BACKREST_VERSION=${TAG} \
           --build-arg REPO_BUILD_TAG=${REPO_TAG} \
@@ -216,7 +216,7 @@ jobs:
         echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin
         IMAGE_TAG="$(echo ${TAG} | cut -d_ -f1)-gpdb"
         docker buildx build --push \
-            -f Dockerfile \
+            -f Dockerfile_make \
             --platform ${BUILD_PLATFORMS} \
             --build-arg BACKREST_VERSION=${TAG} \
             --build-arg REPO_BUILD_TAG=${REPO_TAG} \
@@ -244,7 +244,7 @@ jobs:
         echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin
         IMAGE_TAG="$(echo ${TAG} | cut -d_ -f1)-gpdb"
         docker buildx build --push \
-            -f Dockerfile.alpine \
+            -f Dockerfile_make.alpine \
             --platform ${BUILD_PLATFORMS} \
             --build-arg BACKREST_VERSION=${TAG} \
             --build-arg REPO_BUILD_TAG=${REPO_TAG} \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -32,7 +32,8 @@ RUN apk add --no-cache --update \
     && apk --update add --virtual .backrest-build \
         build-base \
         wget \
-        make \
+        py3-setuptools \
+        meson \
         gcc \
         libpq-dev \
         openssl-dev \
@@ -46,12 +47,11 @@ RUN apk add --no-cache --update \
         libssh2-dev \
     && ln -s /sbin/su-exec /usr/local/bin/gosu \
     && wget ${BACKREST_DOWNLOAD_URL}/${BACKREST_VERSION}.tar.gz -O /tmp/pgbackrest-${BACKREST_VERSION}.tar.gz \
-    && mkdir -p /tmp/pgbackrest-release \
+    && mkdir -p /tmp/pgbackrest-release /tmp/pgbackrest-build \
     && tar -xzf /tmp/pgbackrest-${BACKREST_VERSION}.tar.gz --strip-components=1 -C /tmp/pgbackrest-release \
-    && cd /tmp/pgbackrest-release/src \
-    && ./configure \
-    && make \
-    && cp /tmp/pgbackrest-release/src/pgbackrest /usr/bin/pgbackrest \
+    && meson setup /tmp/pgbackrest-build /tmp/pgbackrest-release \
+    && ninja -C /tmp/pgbackrest-build \
+    && cp /tmp/pgbackrest-build/src/pgbackrest /usr/bin/pgbackrest \
     && groupadd --gid ${BACKREST_GID} ${BACKREST_GROUP} \
     && useradd --shell /bin/bash --uid ${BACKREST_UID} --gid ${BACKREST_GID} -m ${BACKREST_USER} \
     && wget ${BACKREST_COMPLETION_VERSION_URL}/${BACKREST_COMPLETION_VERSION}.tar.gz -O /tmp/pgbackrest-bash-completion-${BACKREST_COMPLETION_VERSION}.tar.gz \
@@ -79,6 +79,7 @@ RUN apk add --no-cache --update \
     && echo "${TZ}" > /etc/timezone \
     && rm -rf \
         /tmp/pgbackrest-release \
+        /tmp/pgbackrest-build \
         /tmp/pgbackrest-bash-completion \
         /tmp/pgbackrest-${BACKREST_VERSION}.tar.gz \
         /tmp/pgbackrest-bash-completion-${BACKREST_COMPLETION_VERSION}.tar.gz \

--- a/Dockerfile_make
+++ b/Dockerfile_make
@@ -7,16 +7,8 @@ ARG BACKREST_COMPLETION_VERSION_URL="https://github.com/woblerr/pgbackrest-bash-
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        # According to the pgBackRest docs for v2.52, the python3-distutils package is needed for build from sources.
-        # See PR https://github.com/pgbackrest/pgbackrest/pull/2338.
-        # The python3-distutils package is deprecated.
-        # For Meson on Ubuntu 22.04 and higher it makes sense to use the package python3-setuptools.
-        # See https://ubuntu.pkgs.org/22.04/ubuntu-universe-amd64/meson_0.61.2-1_all.deb.html
-        # and https://ubuntu.pkgs.org/24.04/ubuntu-universe-amd64/meson_1.3.2-1ubuntu1_all.deb.html
-        # python3-distutils \
-        python3-setuptools \
+        make \
         gcc \
-        meson \
         libpq-dev \
         libssl-dev \
         libxml2-dev \
@@ -33,10 +25,11 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN wget ${BACKREST_DOWNLOAD_URL}/${BACKREST_VERSION}.tar.gz -O /tmp/pgbackrest-${BACKREST_VERSION}.tar.gz \
-    && mkdir -p /tmp/pgbackrest-release /tmp/pgbackrest-build \
+    && mkdir -p /tmp/pgbackrest-release \
     && tar -xzf /tmp/pgbackrest-${BACKREST_VERSION}.tar.gz --strip-components=1 -C /tmp/pgbackrest-release \
-    && meson setup /tmp/pgbackrest-build /tmp/pgbackrest-release \
-    && ninja -C /tmp/pgbackrest-build
+    && cd /tmp/pgbackrest-release/src \
+    && ./configure \
+    && make
 
 RUN wget ${BACKREST_COMPLETION_VERSION_URL}/${BACKREST_COMPLETION_VERSION}.tar.gz -O /tmp/pgbackrest-bash-completion-${BACKREST_COMPLETION_VERSION}.tar.gz \
     && tar -xzf /tmp/pgbackrest-bash-completion-${BACKREST_COMPLETION_VERSION}.tar.gz -C /tmp \
@@ -94,7 +87,7 @@ RUN groupadd --gid ${BACKREST_GID} ${BACKREST_GROUP} \
 
 COPY --chmod=755 files/entrypoint.sh /entrypoint.sh
 COPY --from=builder --chown=${BACKREST_USER}:${BACKREST_GROUP} /tmp/pgbackrest-bash-completion/pgbackrest-completion.sh /home/${BACKREST_USER}/.bash_completion.d/pgbackrest-completion.sh
-COPY --from=builder /tmp/pgbackrest-build/src/pgbackrest /usr/bin/pgbackrest
+COPY --from=builder /tmp/pgbackrest-release/src/pgbackrest /usr/bin/pgbackrest
 
 LABEL \
     org.opencontainers.image.version="${REPO_BUILD_TAG}" \

--- a/Dockerfile_make.alpine
+++ b/Dockerfile_make.alpine
@@ -32,8 +32,7 @@ RUN apk add --no-cache --update \
     && apk --update add --virtual .backrest-build \
         build-base \
         wget \
-        py3-setuptools \
-        meson \
+        make \
         gcc \
         libpq-dev \
         openssl-dev \
@@ -47,11 +46,12 @@ RUN apk add --no-cache --update \
         libssh2-dev \
     && ln -s /sbin/su-exec /usr/local/bin/gosu \
     && wget ${BACKREST_DOWNLOAD_URL}/${BACKREST_VERSION}.tar.gz -O /tmp/pgbackrest-${BACKREST_VERSION}.tar.gz \
-    && mkdir -p /tmp/pgbackrest-release /tmp/pgbackrest-build \
+    && mkdir -p /tmp/pgbackrest-release \
     && tar -xzf /tmp/pgbackrest-${BACKREST_VERSION}.tar.gz --strip-components=1 -C /tmp/pgbackrest-release \
-    && meson setup /tmp/pgbackrest-build /tmp/pgbackrest-release \
-    && ninja -C /tmp/pgbackrest-build \
-    && cp /tmp/pgbackrest-build/src/pgbackrest /usr/bin/pgbackrest \
+    && cd /tmp/pgbackrest-release/src \
+    && ./configure \
+    && make \
+    && cp /tmp/pgbackrest-release/src/pgbackrest /usr/bin/pgbackrest \
     && groupadd --gid ${BACKREST_GID} ${BACKREST_GROUP} \
     && useradd --shell /bin/bash --uid ${BACKREST_UID} --gid ${BACKREST_GID} -m ${BACKREST_USER} \
     && wget ${BACKREST_COMPLETION_VERSION_URL}/${BACKREST_COMPLETION_VERSION}.tar.gz -O /tmp/pgbackrest-bash-completion-${BACKREST_COMPLETION_VERSION}.tar.gz \
@@ -79,7 +79,6 @@ RUN apk add --no-cache --update \
     && echo "${TZ}" > /etc/timezone \
     && rm -rf \
         /tmp/pgbackrest-release \
-        /tmp/pgbackrest-build \
         /tmp/pgbackrest-bash-completion \
         /tmp/pgbackrest-${BACKREST_VERSION}.tar.gz \
         /tmp/pgbackrest-bash-completion-${BACKREST_COMPLETION_VERSION}.tar.gz \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BACKREST_VERSIONS = 2.51 2.52 2.52.1 2.53 2.53.1
 TAG?=2.53.1
+TAG_MESON_BUILD=2.51
 BACKREST_DOWNLOAD_URL = https://github.com/pgbackrest/pgbackrest/archive/release
 BACKREST_GPDB_VERSIONS = 2.47_arenadata4 2.50_arenadata4 2.52_arenadata4
 TAG_GPDB?=2.52_arenadata4
@@ -19,21 +20,25 @@ $(BACKREST_VERSIONS):
 .PHONY: build_version
 build_version:
 	@echo "Build pgbackrest:$(TAG) docker image"
-	docker build --pull -f Dockerfile --build-arg BACKREST_VERSION=$(TAG) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_DOWNLOAD_URL) -t pgbackrest:$(TAG) .
+	@if [ "${TAG}" \< "${TAG_MESON_BUILD}" ]; then \
+		docker build --pull -f Dockerfile_make --build-arg BACKREST_VERSION=$(TAG) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_DOWNLOAD_URL) -t pgbackrest:$(TAG) . ; \
+	else \
+		docker build --pull -f Dockerfile --build-arg BACKREST_VERSION=$(TAG) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_DOWNLOAD_URL) -t pgbackrest:$(TAG) . ; \
+	fi
 	docker run pgbackrest:$(TAG)
 
 .PHONY: $(BACKREST_GPDB_VERSIONS)
 $(BACKREST_GPDB_VERSIONS):
 	$(call gpdb_image_tag,IMAGE_TAG,$@)
 	@echo "Build pgbackrest:$(IMAGE_TAG) docker image"
-	docker build --pull -f Dockerfile --build-arg BACKREST_VERSION=$@ --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_GPDB_DOWNLOAD_URL) -t pgbackrest:$(IMAGE_TAG) .
+	docker build --pull -f Dockerfile_make --build-arg BACKREST_VERSION=$@ --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_GPDB_DOWNLOAD_URL) -t pgbackrest:$(IMAGE_TAG) .
 	docker run pgbackrest:$(IMAGE_TAG)
 
 .PHONY: build_version_gpdb
 build_version_gpdb:
 	$(call gpdb_image_tag,IMAGE_TAG,$(TAG_GPDB))
 	@echo "Build pgbackrest:$(IMAGE_TAG) docker image"
-	docker build --pull -f Dockerfile --build-arg BACKREST_VERSION=$(TAG_GPDB) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_GPDB_DOWNLOAD_URL) -t pgbackrest:$(IMAGE_TAG) .
+	docker build --pull -f Dockerfile_make --build-arg BACKREST_VERSION=$(TAG_GPDB) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_GPDB_DOWNLOAD_URL) -t pgbackrest:$(IMAGE_TAG) .
 	docker run pgbackrest:$(IMAGE_TAG)
 
 .PHONY: $(BACKREST_VERSIONS)-alpine
@@ -45,21 +50,26 @@ $(addsuffix -alpine,$(BACKREST_VERSIONS)):
 .PHONY: build_version_alpine
 build_version_alpine:
 	@echo "Build pgbackrest:$(TAG)-alpine docker image"
-	docker build --pull -f Dockerfile.alpine --build-arg BACKREST_VERSION=$(TAG) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_DOWNLOAD_URL) -t pgbackrest:$(TAG)-alpine .
+	@if [ "${TAG}" \< "${TAG_MESON_BUILD}" ]; then \
+		docker build --pull -f Dockerfile_make.alpine --build-arg BACKREST_VERSION=$(TAG) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_DOWNLOAD_URL) -t pgbackrest:$(TAG)-alpine . ; \
+	else \
+		docker build --pull -f Dockerfile.alpine --build-arg BACKREST_VERSION=$(TAG) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_DOWNLOAD_URL) -t pgbackrest:$(TAG)-alpine . ; \
+	fi
 	docker run pgbackrest:$(TAG)-alpine
 
 .PHONY: $(BACKREST_GPDB_VERSIONS)-alpine
 $(addsuffix -alpine,$(BACKREST_GPDB_VERSIONS)):
 	$(call gpdb_image_tag_alpine,IMAGE_TAG,$@)
 	@echo "Build pgbackrest:$(IMAGE_TAG) docker image"
-	docker build --pull -f Dockerfile.alpine --build-arg BACKREST_VERSION=$(subst -alpine,,$@) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_GPDB_DOWNLOAD_URL) -t pgbackrest:$(IMAGE_TAG) .
+	docker build --pull -f Dockerfile_make.alpine --build-arg BACKREST_VERSION=$(subst -alpine,,$@) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_GPDB_DOWNLOAD_URL) -t pgbackrest:$(IMAGE_TAG) .
 	docker run pgbackrest:$(shell echo $@ | cut -d_ -f1)-gpdb-alpine
 
 .PHONY: build_version_gpdb_alpine
 build_version_gpdb_alpine:
 	$(call gpdb_image_tag_alpine,IMAGE_TAG,$(TAG_GPDB))
 	@echo "Build pgbackrest:$(IMAGE_TAG) docker image"
-	docker build --pull -f Dockerfile.alpine --build-arg BACKREST_VERSION=$(TAG_GPDB) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_GPDB_DOWNLOAD_URL) -t pgbackrest:$(IMAGE_TAG) .
+	docker build --pull -f Dockerfile_make.alpine --build-arg BACKREST_VERSION=$(TAG_GPDB) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_GPDB_DOWNLOAD_URL) -t pgbackrest:$(IMAGE_TAG) .
+	fi
 	docker run pgbackrest:$(IMAGE_TAG)
 
 .PHONY: test-e2e

--- a/README.md
+++ b/README.md
@@ -253,6 +253,28 @@ docker build -f Dockerfile --build-arg BACKREST_VERSION=2.53.1 --build-arg BACKR
 docker build -f Dockerfile.alpine --build-arg BACKREST_VERSION=2.53.1 --build-arg BACKREST_COMPLETION_VERSION=v0.9 -t pgbackrest:2.53.1-alpine .
 ```
 
+### Build pgBackRest < `v2.51`
+
+Since version `v2.51`, the build system for pgBackRest is `meson`. The `autoconf/make` build will not receive any new features and will be removed in future. If you need to build pgBackRest lower than `v2.51`, use the files [Dockerfile_make](./Dockerfile) or [Dockerfile_make.alpine](./Dockerfile_make.alpine).
+
+```bash
+make build_version TAG=2.49
+```
+
+```bash
+make build_version_alpine TAG=2.49
+```
+
+or
+
+```bash
+docker build -f Dockerfile_make --build-arg BACKREST_VERSION=2.49 --build-arg BACKREST_COMPLETION_VERSION=v0.9 -t pgbackrest:2.49 .
+```
+
+```bash
+docker build -f Dockerfile_make.alpine --build-arg BACKREST_VERSION=2.49 --build-arg BACKREST_COMPLETION_VERSION=v0.9 -t pgbackrest:2.49-alpine .
+```
+
 ## Build with Greenplum support
 
 PR [pgbackrest/pull/1833](https://github.com/pgbackrest/pgbackrest/pull/1833) is still not merged into pgBackRest. The separate tags `*-gpdb` are used for pgBackRest images with Greenplum support. When the PR is accepted, separate tags will no longer be needed.


### PR DESCRIPTION
Since version `v2.51`, the build system for pgBackRest is `meson`. The `autoconf/make` build will not receive any new features and will be removed in future. If you need to build pgBackRest lower than `v2.51`, use the files `Dockerfile_make` or `Dockerfile_make.alpine`.

The gpdb build continues to work on `autoconf/make`.