### PR TITLE
Bump bash-completion script to v0.11.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,70 +5,81 @@ BACKREST_DOWNLOAD_URL = https://github.com/pgbackrest/pgbackrest/archive/release
 BACKREST_GPDB_VERSIONS = 2.47_arenadata4 2.50_arenadata4 2.52_arenadata9
 TAG_GPDB?=2.52_arenadata9
 BACKREST_GPDB_DOWNLOAD_URL = https://github.com/arenadata/pgbackrest/archive
-BACKREST_COMP_VERSION?=v0.10
+BACKREST_COMP_VERSION?=v0.11
+BACKREST_OLD_COMP_VERSION?=v0.10
+TAG_BACKREST_OLD_COMP_VERSION?=2.56.0
 UID := $(shell id -u)
 GID := $(shell id -g)
+
 
 all: $(BACKREST_VERSIONS) $(addsuffix -alpine,$(BACKREST_VERSIONS)) $(BACKREST_GPDB_VERSIONS) $(addsuffix -alpine,$(BACKREST_GPDB_VERSIONS))
 
 .PHONY: $(BACKREST_VERSIONS)
 $(BACKREST_VERSIONS):
+	$(call get_completion_version,COMP_VERSION,$@)
 	@echo "Build pgbackrest:$@ docker image"
-	docker build --pull -f Dockerfile --build-arg BACKREST_VERSION=$@ --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_DOWNLOAD_URL) -t pgbackrest:$@ .
+	docker build --pull -f Dockerfile --build-arg BACKREST_VERSION=$@ --build-arg BACKREST_COMPLETION_VERSION=$(COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_DOWNLOAD_URL) -t pgbackrest:$@ .
 	docker run pgbackrest:$@
 
 .PHONY: build_version
 build_version:
+	$(call get_completion_version,COMP_VERSION,$(TAG))
 	@echo "Build pgbackrest:$(TAG) docker image"
 	@if [ "${TAG}" \< "${TAG_MESON_BUILD}" ]; then \
-		docker build --pull -f Dockerfile_make --build-arg BACKREST_VERSION=$(TAG) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_DOWNLOAD_URL) -t pgbackrest:$(TAG) . ; \
+		docker build --pull -f Dockerfile_make --build-arg BACKREST_VERSION=$(TAG) --build-arg BACKREST_COMPLETION_VERSION=$(COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_DOWNLOAD_URL) -t pgbackrest:$(TAG) . ; \
 	else \
-		docker build --pull -f Dockerfile --build-arg BACKREST_VERSION=$(TAG) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_DOWNLOAD_URL) -t pgbackrest:$(TAG) . ; \
+		docker build --pull -f Dockerfile --build-arg BACKREST_VERSION=$(TAG) --build-arg BACKREST_COMPLETION_VERSION=$(COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_DOWNLOAD_URL) -t pgbackrest:$(TAG) . ; \
 	fi
-	docker run pgbackrest:$(TAG)
+	@docker run pgbackrest:$(TAG)
 
 .PHONY: $(BACKREST_GPDB_VERSIONS)
 $(BACKREST_GPDB_VERSIONS):
 	$(call gpdb_image_tag,IMAGE_TAG,$@)
+	$(call get_completion_version,COMP_VERSION,$@)
 	@echo "Build pgbackrest:$(IMAGE_TAG) docker image"
-	docker build --pull -f Dockerfile_make --build-arg BACKREST_VERSION=$@ --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_GPDB_DOWNLOAD_URL) -t pgbackrest:$(IMAGE_TAG) .
+	docker build --pull -f Dockerfile_make --build-arg BACKREST_VERSION=$@ --build-arg BACKREST_COMPLETION_VERSION=$(COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_GPDB_DOWNLOAD_URL) -t pgbackrest:$(IMAGE_TAG) .
 	docker run pgbackrest:$(IMAGE_TAG)
 
 .PHONY: build_version_gpdb
 build_version_gpdb:
 	$(call gpdb_image_tag,IMAGE_TAG,$(TAG_GPDB))
+	$(call get_completion_version,COMP_VERSION,$(TAG_GPDB))
 	@echo "Build pgbackrest:$(IMAGE_TAG) docker image"
-	docker build --pull -f Dockerfile_make --build-arg BACKREST_VERSION=$(TAG_GPDB) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_GPDB_DOWNLOAD_URL) -t pgbackrest:$(IMAGE_TAG) .
+	docker build --pull -f Dockerfile_make --build-arg BACKREST_VERSION=$(TAG_GPDB) --build-arg BACKREST_COMPLETION_VERSION=$(COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_GPDB_DOWNLOAD_URL) -t pgbackrest:$(IMAGE_TAG) .
 	docker run pgbackrest:$(IMAGE_TAG)
 
 .PHONY: $(BACKREST_VERSIONS)-alpine
 $(addsuffix -alpine,$(BACKREST_VERSIONS)):
+	$(call get_completion_version,COMP_VERSION,$(subst -alpine,,$@))
 	@echo "Build pgbackrest:$@ docker image"
-	docker build --pull -f Dockerfile.alpine --build-arg BACKREST_VERSION=$(subst -alpine,,$@) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_DOWNLOAD_URL) -t pgbackrest:$@ .
+	docker build --pull -f Dockerfile.alpine --build-arg BACKREST_VERSION=$(subst -alpine,,$@) --build-arg BACKREST_COMPLETION_VERSION=$(COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_DOWNLOAD_URL) -t pgbackrest:$@ .
 	docker run pgbackrest:$@
 
 .PHONY: build_version_alpine
 build_version_alpine:
+	$(call get_completion_version,COMP_VERSION,$(TAG))
 	@echo "Build pgbackrest:$(TAG)-alpine docker image"
 	@if [ "${TAG}" \< "${TAG_MESON_BUILD}" ]; then \
-		docker build --pull -f Dockerfile_make.alpine --build-arg BACKREST_VERSION=$(TAG) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_DOWNLOAD_URL) -t pgbackrest:$(TAG)-alpine . ; \
+		docker build --pull -f Dockerfile_make.alpine --build-arg BACKREST_VERSION=$(TAG) --build-arg BACKREST_COMPLETION_VERSION=$(COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_DOWNLOAD_URL) -t pgbackrest:$(TAG)-alpine . ; \
 	else \
-		docker build --pull -f Dockerfile.alpine --build-arg BACKREST_VERSION=$(TAG) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_DOWNLOAD_URL) -t pgbackrest:$(TAG)-alpine . ; \
+		docker build --pull -f Dockerfile.alpine --build-arg BACKREST_VERSION=$(TAG) --build-arg BACKREST_COMPLETION_VERSION=$(COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_DOWNLOAD_URL) -t pgbackrest:$(TAG)-alpine . ; \
 	fi
 	docker run pgbackrest:$(TAG)-alpine
 
 .PHONY: $(BACKREST_GPDB_VERSIONS)-alpine
 $(addsuffix -alpine,$(BACKREST_GPDB_VERSIONS)):
 	$(call gpdb_image_tag_alpine,IMAGE_TAG,$@)
+	$(call get_completion_version,COMP_VERSION,$(subst -alpine,,$@))
 	@echo "Build pgbackrest:$(IMAGE_TAG) docker image"
-	docker build --pull -f Dockerfile_make.alpine --build-arg BACKREST_VERSION=$(subst -alpine,,$@) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_GPDB_DOWNLOAD_URL) -t pgbackrest:$(IMAGE_TAG) .
+	docker build --pull -f Dockerfile_make.alpine --build-arg BACKREST_VERSION=$(subst -alpine,,$@) --build-arg BACKREST_COMPLETION_VERSION=$(COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_GPDB_DOWNLOAD_URL) -t pgbackrest:$(IMAGE_TAG) .
 	docker run pgbackrest:$(shell echo $@ | cut -d_ -f1)-gpdb-alpine
 
 .PHONY: build_version_gpdb_alpine
 build_version_gpdb_alpine:
 	$(call gpdb_image_tag_alpine,IMAGE_TAG,$(TAG_GPDB))
+	$(call get_completion_version,COMP_VERSION,$(TAG_GPDB))
 	@echo "Build pgbackrest:$(IMAGE_TAG) docker image"
-	docker build --pull -f Dockerfile_make.alpine --build-arg BACKREST_VERSION=$(TAG_GPDB) --build-arg BACKREST_COMPLETION_VERSION=$(BACKREST_COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_GPDB_DOWNLOAD_URL) -t pgbackrest:$(IMAGE_TAG) .
+	docker build --pull -f Dockerfile_make.alpine --build-arg BACKREST_VERSION=$(TAG_GPDB) --build-arg BACKREST_COMPLETION_VERSION=$(COMP_VERSION) --build-arg BACKREST_DOWNLOAD_URL=$(BACKREST_GPDB_DOWNLOAD_URL) -t pgbackrest:$(IMAGE_TAG) .
 	docker run pgbackrest:$(IMAGE_TAG)
 
 .PHONY: test-e2e
@@ -119,10 +130,25 @@ define set_permissions
 	@chmod 600 e2e_tests/conf/ssh/* e2e_tests/conf/pg/sshd/* e2e_tests/conf/sftp/sshd-rsa/* e2e_tests/conf/sftp/sshd-ed25519/* e2e_tests/conf/pgbackrest/cert/*
 endef
 
+define extract_version
+	$(shell echo $(1) | cut -d_ -f1)
+endef
+
 define gpdb_image_tag
-	$(eval $(1) := $(shell echo $(2) | cut -d_ -f1)-gpdb)
+	$(eval $(1) := $(call extract_version,$(2))-gpdb)
 endef
 
 define gpdb_image_tag_alpine
-	$(eval $(1) := $(shell echo $(2) | cut -d_ -f1)-gpdb-alpine)
+	$(eval $(1) := $(call extract_version,$(2))-gpdb-alpine)
+endef
+
+define get_completion_version
+	$(eval VERSION_NUM := $(call extract_version,$(2)))
+	$(eval $(1) := $(shell \
+		if [ "$(VERSION_NUM)" \< "$(TAG_BACKREST_OLD_COMP_VERSION)" ]; then \
+			echo "$(BACKREST_OLD_COMP_VERSION)"; \
+		else \
+			echo "$(BACKREST_COMP_VERSION)"; \
+		fi \
+	))
 endef


### PR DESCRIPTION
Automatically select completion script version based on pgBackRest version. Versions pgBackRest < `v2.56.0` use `v0.10` completion script, versions >= `v2.56.0` use `v0.11` or later.

Refactored Makefile functions to reduce code duplication and improve maintainability.